### PR TITLE
fix: 모바일 기기별로 indicator 올바르지 않게 표시되는 버그 수정

### DIFF
--- a/client/src/components/CarouselBasic/CarouselBasic.tsx
+++ b/client/src/components/CarouselBasic/CarouselBasic.tsx
@@ -3,8 +3,6 @@ import styled from 'styled-components'
 import { StyledWrapper } from '../../styles/StyledWrapper'
 import { ProductDetailImg } from '../../apis/graphqlQuery'
 import {
-  CAROUSEL_BASIC_INIT_BOUNDING_RECT_X_ERR,
-  CAROUSEL_BASIC_INIT_BOUNDING_RECT_Y_ERR,
   CAROUSEL_BASIC_INTERSECTION_RATIO_THRESHOLD,
   CAROUSEL_BASIC_INTERSECTION_THRESHOLD,
 } from '../../utils/constants'
@@ -81,17 +79,11 @@ export const CarouselBasic = (props: Props) => {
   const [bannerIndex, setBannerIndex] = useState<number>(0)
 
   const isInitialAdjustment = (entry: IntersectionObserverEntry): boolean => {
-    return (
-      entry.boundingClientRect.x === CAROUSEL_BASIC_INIT_BOUNDING_RECT_X_ERR &&
-      entry.boundingClientRect.y === CAROUSEL_BASIC_INIT_BOUNDING_RECT_Y_ERR
-    )
+    return entry.boundingClientRect.x === sliderRef.current?.getBoundingClientRect().width
   }
 
   useEffect(() => {
-    const bannerObserveHandler = (
-      entries: IntersectionObserverEntry[],
-      observer: IntersectionObserver
-    ) => {
+    const bannerObserveHandler = (entries: IntersectionObserverEntry[]) => {
       entries.forEach((entry) => {
         if (
           entry.isIntersecting &&

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -107,9 +107,7 @@ export const KR_WEEKDAY = [
 // relate to CategoryListSection component's lazyloading implements
 // 현재 포커싱된 카테고리 이후 몇 개의 카테고리의 loading을 진행할 것인가에 대한 상수
 export const CATEGORY_SECTION_LAZYLOAD_ADDER = 2
-// Carousel Basic indicator 초기 오작동 버그 검증을 위한 상수
-export const CAROUSEL_BASIC_INIT_BOUNDING_RECT_X_ERR = 375
-export const CAROUSEL_BASIC_INIT_BOUNDING_RECT_Y_ERR = 51
+
 export const CAROUSEL_BASIC_INTERSECTION_RATIO_THRESHOLD = 0.9
 export const CAROUSEL_BASIC_INTERSECTION_THRESHOLD = 0.9
 


### PR DESCRIPTION
- 상수가 아닌 부모 element의 width를 이용해 에러 체크

## PR 요약

> 해당 PR이 어떤 PR인지에 대한 간략한 설명을 추가합니다.

모바일 기기별로 대응이 되지않는 버그를 수정했습니다.

## 체크리스트

> 작성자, 리뷰어 모두가 확인해야할 사항들 입니다.

- [ ] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [ ] 작성한 코드에 대해 모두 이해하였는지 확인
- [ ] 관련된 label 추가했는지 확인

## 관련 이슈

> 이 PR이 머지되었을 때 closed될 이슈의 번호를 지정합니다.

- resolve #79 

